### PR TITLE
fix test_legacy_app_failed_install

### DIFF
--- a/legacy_app_ynh/scripts/install
+++ b/legacy_app_ynh/scripts/install
@@ -10,6 +10,9 @@ is_public=$YNH_APP_ARG_IS_PUBLIC
 # Check domain/path availability
 sudo yunohost app checkurl $domain/$path -a $app
 
+# Check folder availability
+test ! -e "/var/www/$app/"
+
 # Add config for nginx
 sudo sed -i "s@PATHTOCHANGE@$path@g" ../conf/nginx.conf
 sudo sed -i "s@FOLDER@$app/@g" ../conf/nginx.conf


### PR DESCRIPTION
https://github.com/YunoHost/yunohost/blob/be3ffce0038b6b3c82a571827d4180ddac24aa97/src/yunohost/tests/test_apps.py#L255

Doesn't fail if we don't check the path `/var/www/$app`